### PR TITLE
update GitHub profile links to githubcard.com

### DIFF
--- a/src/app/user/[username]/page.tsx
+++ b/src/app/user/[username]/page.tsx
@@ -12,7 +12,7 @@ export default async function Home(props: {
           <h1 className="text-5xl font-semibold tracking-tighter">
             GitHub Stats for&nbsp;
             <a
-              href={`https://github.com/${params.username}`}
+              href={`https://githubcard.com/${params.username}`}
               target="blank"
               rel="noopener noreferrer"
               className="underline"


### PR DESCRIPTION
GitHub has migrated profile URLs from github.com to githubcard.com. Updated the profile link to point to the new domain.